### PR TITLE
Fix: New line not working in Firefox

### DIFF
--- a/style.css
+++ b/style.css
@@ -48,6 +48,7 @@ textarea {
   line-height: 4rem;
   padding: 0px 0px 0 5rem;
   word-break: break-word;
+  white-space: pre-wrap;
 
   background-color: snow;
   background-image: linear-gradient(


### PR DESCRIPTION
When clicking 'Enter' in Firefox, a new line is now created. Before, only a space was created when clicking 'Enter'.